### PR TITLE
Added File::from_path which shadows File::new

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "taglib"
 description = "Rust bindings for TagLib"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Emmanuele Bassi <ebassi@gnome.org>"]
 license = "MIT"
 repository = "https://github.com/ebassi/taglib-rust/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ extern crate taglib_sys as sys;
 
 use libc::{c_char};
 use std::ffi::{CString, CStr};
+use std::path::Path;
 
 use sys as ll;
 
@@ -227,7 +228,6 @@ impl File {
         Ok(s) => s,
         _ => return Err(FileError::InvalidFileName)
       };
-      
     let filename_c_ptr = filename_c.as_ptr();
 
     let f = unsafe { ll::taglib_file_new(filename_c_ptr) };
@@ -237,6 +237,26 @@ impl File {
 
     Ok(File { raw: f })
   }
+
+  /// Creates a new `taglib::File` for the given `path`.
+  pub fn from_path<P>(path: P) -> Result<File, FileError>
+    where P: AsRef<Path>,
+      std::vec::Vec<u8>: std::convert::From<P> 
+    {
+      let filename_c =
+        match CString::new(path) {
+          Ok(s) => s,
+          _ => return Err(FileError::InvalidFileName)
+        };
+      let filename_c_ptr = filename_c.as_ptr();
+
+      let f = unsafe { ll::taglib_file_new(filename_c_ptr) };
+      if f.is_null() {
+        return Err(FileError::InvalidFile);
+      }
+
+      Ok(File { raw: f })
+    }
 
   /// Creates a new `taglib::File` for the given `filename` and type of file.
   pub fn new_type(filename: &str, filetype: FileType) -> Result<File, FileError> {


### PR DESCRIPTION
This allows one to create new TagLib::File structs from whatever
implements `AsRef<std::path::Path>`.