### PR TITLE
Use optional types for missing fields

### DIFF
--- a/examples/tagreader.rs
+++ b/examples/tagreader.rs
@@ -21,13 +21,13 @@ pub fn main() {
     match file.tag() {
       Ok(t) => {
         println!("-- TAG --");
-        println!("title   - {}", t.title());
-        println!("artist  - {}", t.artist());
-        println!("album   - {}", t.album());
-        println!("year    - {}", t.year());
-        println!("comment - {}", t.comment());
-        println!("track   - {}", t.track());
-        println!("genre   - {}", t.genre());
+        println!("title   - {}", t.title().unwrap_or_default());
+        println!("artist  - {}", t.artist().unwrap_or_default());
+        println!("album   - {}", t.album().unwrap_or_default());
+        println!("year    - {}", t.year().unwrap_or_default());
+        println!("comment - {}", t.comment().unwrap_or_default());
+        println!("track   - {}", t.track().unwrap_or_default());
+        println!("genre   - {}", t.genre().unwrap_or_default());
       },
       Err(e) => {
         println!("No available tags for {} (error: {:?})", arg, e);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,14 +29,23 @@ use std::ffi::{CString, CStr};
 
 use sys as ll;
 
-fn c_str_to_str(c_str: *const c_char) -> String {
+fn c_str_to_str(c_str: *const c_char) -> Option<String> {
   if c_str.is_null() {
-    String::new()
+    None
   }
   else {
     let bytes = unsafe { CStr::from_ptr(c_str).to_bytes() };
-    String::from_utf8_lossy(bytes).to_string()
+
+    if bytes.is_empty() {
+      None
+    } else {
+      Some(String::from_utf8_lossy(bytes).to_string())
+    }
   }
+}
+
+fn u32_to_option(n: u32) -> Option<u32> {
+  if n == 0 { None } else { Some(n) }
 }
 
 /// A representation of an audio file, with meta-data and properties.
@@ -65,8 +74,8 @@ pub struct AudioProperties<'a> {
 }
 
 impl<'a> Tag<'a> {
-  /// Returns the track name, or an empty string if no track name is present.
-  pub fn title(&self) -> String {
+  /// Returns the track name, if any.
+  pub fn title(&self) -> Option<String> {
     let res = unsafe { ll::taglib_tag_title(self.raw) };
     c_str_to_str(res)
   }
@@ -78,8 +87,8 @@ impl<'a> Tag<'a> {
     unsafe { ll::taglib_tag_set_title(self.raw, s); }
   }
 
-  /// Returns the artist name, or an empty string if no artist name is present.
-  pub fn artist(&self) -> String {
+  /// Returns the artist name, if any.
+  pub fn artist(&self) -> Option<String> {
     let res = unsafe { ll::taglib_tag_artist(self.raw) };
     c_str_to_str(res)
   }
@@ -91,8 +100,8 @@ impl<'a> Tag<'a> {
     unsafe { ll::taglib_tag_set_artist(self.raw, s); }
   }
 
-  /// Returns the album name, or an empty string if no album name is present.
-  pub fn album(&self) -> String {
+  /// Returns the album name, if any.
+  pub fn album(&self) -> Option<String> {
     let res = unsafe { ll::taglib_tag_album(self.raw) };
     c_str_to_str(res)
   }
@@ -104,9 +113,8 @@ impl<'a> Tag<'a> {
     unsafe { ll::taglib_tag_set_album(self.raw, s); }
   }
 
-  /// Returns the track comment, or an empty string if no track comment is
-  /// present.
-  pub fn comment(&self) -> String {
+  /// Returns the track comment, if any.
+  pub fn comment(&self) -> Option<String> {
     let res = unsafe { ll::taglib_tag_comment(self.raw) };
     c_str_to_str(res)
   }
@@ -118,8 +126,8 @@ impl<'a> Tag<'a> {
     unsafe { ll::taglib_tag_set_comment(self.raw, s); }
   }
 
-  /// Returns the genre name, or an empty string if no genre name is present.
-  pub fn genre(&self) -> String {
+  /// Returns the genre name, if any.
+  pub fn genre(&self) -> Option<String> {
     let res = unsafe { ll::taglib_tag_genre(self.raw) };
     c_str_to_str(res)
   }
@@ -131,9 +139,9 @@ impl<'a> Tag<'a> {
     unsafe { ll::taglib_tag_set_genre(self.raw, s); }
   }
 
-  /// Returns the year, or 0 if no year is present.
-  pub fn year(&self) -> u32 {
-    unsafe { ll::taglib_tag_year(self.raw) as u32 }
+  /// Returns the year, if any.
+  pub fn year(&self) -> Option<u32> {
+    u32_to_option(unsafe { ll::taglib_tag_year(self.raw) as u32 })
   }
 
   /// Sets the year.
@@ -141,9 +149,9 @@ impl<'a> Tag<'a> {
     unsafe { ll::taglib_tag_set_year(self.raw, year); }
   }
 
-  /// Returns the track number, or 0 if no track number is present.
-  pub fn track(&self) -> u32 {
-    unsafe { ll::taglib_tag_track(self.raw) as u32 }
+  /// Returns the track number, if any.
+  pub fn track(&self) -> Option<u32> {
+    u32_to_option(unsafe { ll::taglib_tag_track(self.raw) as u32 })
   }
 
   /// Sets the track number.


### PR DESCRIPTION
Instead of returning an empty string, None is returned instead.

This is more inline with what is considered idiomatic rust. 