### PR TITLE
Remove reference to file in AudioProperties and Tag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ name = "taglib"
 path = "src/lib.rs"
 
 [dependencies]
-libc = "0.1"
+libc = "0.2"
 
 [dependencies.taglib-sys]
 path = "taglib-sys"

--- a/examples/tagreader.rs
+++ b/examples/tagreader.rs
@@ -21,13 +21,13 @@ pub fn main() {
     match file.tag() {
       Ok(t) => {
         println!("-- TAG --");
-        println!("title   - {}", t.title());
-        println!("artist  - {}", t.artist());
-        println!("album   - {}", t.album());
-        println!("year    - {}", t.year());
-        println!("comment - {}", t.comment());
-        println!("track   - {}", t.track());
-        println!("genre   - {}", t.genre());
+        println!("title   - {}", t.title.unwrap_or_default());
+        println!("artist  - {}", t.artist.unwrap_or_default());
+        println!("album   - {}", t.album.unwrap_or_default());
+        println!("comment - {}", t.comment.unwrap_or_default());
+        println!("genre   - {}", t.genre.unwrap_or_default());
+        println!("year    - {}", t.year.unwrap_or(0));
+        println!("track   - {}", t.track.unwrap_or(0));
       },
       Err(e) => {
         println!("No available tags for {} (error: {:?})", arg, e);
@@ -36,13 +36,13 @@ pub fn main() {
 
     match file.audioproperties() {
       Ok(p) => {
-        let secs = p.length() % 60;
-        let mins = (p.length() - secs) / 60;
+        let secs = p.length % 60;
+        let mins = (p.length - secs) / 60;
 
         println!("-- AUDIO --");
-        println!("bitrate     - {}", p.bitrate());
-        println!("sample rate - {}", p.samplerate());
-        println!("channels    - {}", p.channels());
+        println!("bitrate     - {}", p.bitrate);
+        println!("sample rate - {}", p.samplerate);
+        println!("channels    - {}", p.channels);
         println!("length      - {}m:{}s", mins, secs);
       },
       Err(e) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,7 @@ use sys as ll;
 fn c_str_to_str(c_str: *const c_char) -> String {
   if c_str.is_null() {
     String::new()
-  }
-  else {
+  } else {
     let bytes = unsafe { CStr::from_ptr(c_str).to_bytes() };
     String::from_utf8_lossy(bytes).to_string()
   }
@@ -49,9 +48,8 @@ pub struct File {
 /// Each `Tag` instance can only be created by the `taglib::File::tag()`
 /// method.
 #[allow(dead_code)]
-pub struct Tag<'a> {
-  raw: *mut ll::TagLib_Tag,
-  file: &'a File,
+pub struct Tag {
+  raw: *mut ll::TagLib_Tag
 }
 
 /// Common audio file properties.
@@ -59,12 +57,11 @@ pub struct Tag<'a> {
 /// Instances of `AudioProperties` can only be created through the
 /// `taglib::File::audioproperties()` method.
 #[allow(dead_code)]
-pub struct AudioProperties<'a> {
+pub struct AudioProperties {
   raw: *const ll::TagLib_AudioProperties,
-  file: &'a File,
 }
 
-impl<'a> Tag<'a> {
+impl Tag {
   /// Returns the track name, or an empty string if no track name is present.
   pub fn title(&self) -> String {
     let res = unsafe { ll::taglib_tag_title(self.raw) };
@@ -152,7 +149,7 @@ impl<'a> Tag<'a> {
   }
 }
 
-impl<'a> AudioProperties<'a> {
+impl AudioProperties {
   /// Returns the length, in seconds, of the track.
   pub fn length(&self) -> u32 {
     unsafe { ll::taglib_audioproperties_length(self.raw) as u32 }
@@ -227,7 +224,7 @@ impl File {
         Ok(s) => s,
         _ => return Err(FileError::InvalidFileName)
       };
-      
+
     let filename_c_ptr = filename_c.as_ptr();
 
     let f = unsafe { ll::taglib_file_new(filename_c_ptr) };
@@ -261,9 +258,8 @@ impl File {
 
     if res.is_null() {
       Err(FileError::NoAvailableTag)
-    }
-    else {
-      Ok(Tag { raw: res, file: self })
+    } else {
+      Ok(Tag { raw: res })
     }
   }
 
@@ -278,9 +274,8 @@ impl File {
 
     if res.is_null() {
       Err(FileError::NoAvailableAudioProperties)
-    }
-    else {
-      Ok(AudioProperties { raw: res, file: self })
+    } else {
+      Ok(AudioProperties { raw: res })
     }
   }
 


### PR DESCRIPTION
Previously a handle to `File` was kept around in `Tag` and `AudioProperties`
so that the raw file pointer wouldn't be dropped while it was being used.

This made it difficult to just pass the tag around as a user of the API,
due to having to keep the `file` object alive as well.

For example, this would result in a lifetime error because the file object
does not live long enough:

```
taglib::File::new(path).and_then(|f| f.tag())
```

In this change the `Tag` and `AudioProperties` are created when request from
the file, E.g. `file.tag()` and there is no raw pointers being passed around.

If the user wishes to save new tags they pass the tag struct in to the `save`
function directly instead (`AudioProperties` can't be changed).

This fixes the issue for PR #7 causing a failure because of the file pointer deallocation. It also (unfortunately) includes the changes proposed in PR #8 as I was doing both of the changes concurrently.