### PR TITLE
Fix string leak

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,6 +234,7 @@ pub enum FileError {
 impl Drop for File {
     fn drop(&mut self) {
         unsafe {
+            ll::taglib_tag_free_strings();
             ll::taglib_file_free(self.raw);
         }
     }


### PR DESCRIPTION
All strings from tags are leaked since ll::taglib_tag_free_strings() is not called on drop. Can be reproduced in the existing unit tests.

CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="valgrind --leak-check=full" cargo test
