### PR TITLE
Fix Unicode paths on Windows (& accept more paths on Unix)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,7 @@ impl File {
     }
 
     /// Returns the `taglib::Tag` instance for the given file.
-    pub fn tag(&self) -> Result<Tag, FileError> {
+    pub fn tag(&self) -> Result<Tag<'_>, FileError> {
         let res = unsafe { ll::taglib_file_tag(self.raw) };
 
         if res.is_null() {
@@ -344,7 +344,7 @@ impl File {
     }
 
     /// Returns the `taglib::AudioProperties` instance for the given file.
-    pub fn audioproperties(&self) -> Result<AudioProperties, FileError> {
+    pub fn audioproperties(&self) -> Result<AudioProperties<'_>, FileError> {
         let res = unsafe { ll::taglib_file_audioproperties(self.raw) };
 
         if res.is_null() {

--- a/taglib-sys/src/lib.rs
+++ b/taglib-sys/src/lib.rs
@@ -21,7 +21,7 @@
 #![allow(non_camel_case_types)]
 extern crate libc;
 
-use libc::{c_int, c_uint, c_char, c_void};
+use libc::{c_char, c_int, c_uint, c_void, wchar_t};
 
 // Public types; these are all opaque pointer types
 pub type TagLib_File = c_void;
@@ -45,8 +45,15 @@ pub const TAGLIB_FILE_ASF: TagLib_FileType = 9;
 // tag_c.h
 extern "C" {
     pub fn taglib_file_new(filename: *const c_char) -> *mut TagLib_File;
+    #[cfg(target_os = "windows")]
+    pub fn taglib_file_new_wchar(filename: *const wchar_t) -> *mut TagLib_File;
     pub fn taglib_file_new_type(
         filename: *const c_char,
+        filetype: TagLib_FileType,
+    ) -> *mut TagLib_File;
+    #[cfg(target_os = "windows")]
+     pub fn taglib_file_new_type_wchar(
+        filename: *const wchar_t,
         filetype: TagLib_FileType,
     ) -> *mut TagLib_File;
     pub fn taglib_file_is_valid(file: *mut TagLib_File) -> TagLib_Bool;


### PR DESCRIPTION
Hello,

I have run into #11 on my Windows machine. I believe this is because passing UTF-8 to the system file APIs simply does not actually work for Windows, and so calling `taglib_file_new` and `taglib_file_new_type` fails as well.

Instead, this pull request makes it so on Windows, the Paths are encoded in UTF-16/WTF-16, and passed through `taglib_file_new_wchar` and `taglib_file_new_type_wchar` (two bindings that only exist on Windows).

I also tweaked the Unix code for `taglib_file_new` and `taglib_file_new_type` to avoid the intermediate conversion to UTF-8, as other paths than pure UTF-8 should be valid on Unix platforms as well.

Finally, I change the API for `File::new_type` to take a `P: AsRef<Path>` argument for its `filename`, rather than just an `&str` (to make the code more consistent). This should probably be considered a breaking change; perhaps I should have bumped the semver.

Depending on if/when this is able to be merged, if anyone else just needs a quick fix for Unicode on Windows, you can patch in my fork:
```
[patch.crates-io]
taglib = { git = "https://github.com/yourname3/taglib-rust.git" }
```